### PR TITLE
Missing comma after bidfloor

### DIFF
--- a/spotxchange/example-video-request-multiple_impr.md
+++ b/spotxchange/example-video-request-multiple_impr.md
@@ -143,7 +143,7 @@ object. A few notes about specific fields in the example:
     },
     {
       "id": "3",
-      "bidfloor": 2.00
+      "bidfloor": 2.00,
       "video": {
         "mimes": [
           "video/x-flv",


### PR DESCRIPTION
l.146 has a missing comma, breaking the example JSON object

Comma added
